### PR TITLE
Fix #19 - crash when no frames in display layout

### DIFF
--- a/lib/propresenter_communication.js
+++ b/lib/propresenter_communication.js
@@ -26,12 +26,6 @@ function interpretLayouts(displayLayouts) {
     layout.border = layoutdata.attributes.showBorder[0] == '1';
     layout.width = parseInt(layoutdata.attributes.width);
     layout.height = parseInt(layoutdata.attributes.height);
-    if (layoutdata.children.length > 0) {
-      var minX = layoutdata.children[0].xAxis;
-      var minY = layoutdata.children[0].yAxis;
-      var maxX = minX + layoutdata.children[0].width;
-      var maxY = minY + layoutdata.children[0].height;
-    }
     layout.fields = {};
 
     for(var j=0; j < layoutdata.children.length; j++) {

--- a/lib/propresenter_communication.js
+++ b/lib/propresenter_communication.js
@@ -26,10 +26,12 @@ function interpretLayouts(displayLayouts) {
     layout.border = layoutdata.attributes.showBorder[0] == '1';
     layout.width = parseInt(layoutdata.attributes.width);
     layout.height = parseInt(layoutdata.attributes.height);
-    var minX = layoutdata.children[0].xAxis;
-    var minY = layoutdata.children[0].yAxis;
-    var maxX = minX + layoutdata.children[0].width;
-    var maxY = minY + layoutdata.children[0].height;
+    if (layoutdata.children.length > 0) {
+      var minX = layoutdata.children[0].xAxis;
+      var minY = layoutdata.children[0].yAxis;
+      var maxX = minX + layoutdata.children[0].width;
+      var maxY = minY + layoutdata.children[0].height;
+    }
     layout.fields = {};
 
     for(var j=0; j < layoutdata.children.length; j++) {


### PR DESCRIPTION
Only reference children of the layout (frames) if they exist.    Note: not sure what the original point of the (now conditional) code is - it may be vestigal.