### PR TITLE
Pro6 color fixes

### DIFF
--- a/lib/propresenter_communication.js
+++ b/lib/propresenter_communication.js
@@ -26,6 +26,7 @@ function interpretLayouts(displayLayouts) {
     layout.border = layoutdata.attributes.showBorder[0] == '1';
     layout.width = parseInt(layoutdata.attributes.width);
     layout.height = parseInt(layoutdata.attributes.height);
+
     layout.fields = {};
 
     for(var j=0; j < layoutdata.children.length; j++) {
@@ -70,24 +71,36 @@ function parseTime(timestr) {
   return seconds;
 }
 
+function normalizeColor(colorVal) {
+  // pp5 (may) use 0-255
+  // pp6 uses a float 0 <= val <= 1
+  // return a value in 0-255 range, making best guess as to what is meant
+  var result = 0;
+  var floatVal = parseFloat(colorVal);
+  if (floatVal <= 1E0) result = (floatVal*255).toFixed();    // pp6 - scale 
+  if (floatVal > 1) result = floatVal.toFixed();             // pp5 - 2-255
+  if (colorVal == "1") result = 1;                           // treat integer 1 (vs. "1E0") as pp5 mode
+  return result; 
+}
+
 function parseColors(data) {
   if (typeof data != "undefined" && data != null) {
-	if (typeof data.red != "undefined" && data.red != null)
-	  data.red = 0;
-	if (typeof data.green != "undefined" && data.green != null)
-	  data.green = 0;
-	if (typeof data.blue != "undefined" && data.blue != null)
-	  data.blue = 0;
-	if (typeof data.alpha != "undefined" && data.alpha != null)
-	  data.alpha = 1;
+  	if (typeof data.red == "undefined" || data.red == null)
+  	  data.red = 0;
+  	if (typeof data.green == "undefined" || data.green == null)
+  	  data.green = 0;
+  	if (typeof data.blue == "undefined" || data.blue == null)
+  	  data.blue = 0;
+  	if (typeof data.alpha == "undefined" || data.alpha == null)
+  	  data.alpha = 1;
   }
   else {
 	  data = {red: 0, green: 0, blue: 0, alpha: 1};
   }
-  var red = parseFloat(data.red).toFixed() * 255;
-  var green = parseFloat(data.green).toFixed() * 255;
-  var blue = parseFloat(data.blue).toFixed() * 255;
-  var alpha = parseFloat(data.alpha).toFixed() * 255;
+  var red = normalizeColor(data.red);
+  var green = normalizeColor(data.green);
+  var blue = normalizeColor(data.blue);
+  var alpha = (parseFloat(data.alpha));
   var color = 'rgba(' + red + ',' + green + ',' + blue + ',' + alpha + ')';
   data['htmlColor'] = color;
   return data;

--- a/test/propresenter_communication_spec.js
+++ b/test/propresenter_communication_spec.js
@@ -39,49 +39,51 @@ describe("ProPresenter Communication", function() {
   
   describe("#parseColors()", function() {
 		  it("should parse red", function() {
-			  var input = {red:255,green:0,blue:0,alpha:0}
-			  var expected = input;
-			  expected.htmlColor = 'rgba(255,0,0,0)'
-			  expect(parseColors(input)).to.equal(expected);
+			  var input = {red:255,green:0,blue:0,alpha:0};
+			  expect(parseColors(input).htmlColor).to.equal('rgba(255,0,0,0)');
 		  })
 		  
 		  it("should parse green", function() {
-			var input = {red:0,green:255,blue:0,alpha:0}
-		  	var expected = input;
-		  	expected.htmlColor = 'rgba(0,255,0,0)';
-		  	expect(parseColors(input)).to.equal(expected);
+			var input = {red:0,green:255,blue:0,alpha:0};
+		  	expect(parseColors(input).htmlColor).to.equal('rgba(0,255,0,0)');
 	  	  })
 		  
 		  it("should parse blue", function() {
-			var input = {red:0,green:0,blue:255,alpha:0}
-			var expected = input;
-			expected.htmlColor = 'rgba(0,0,255,0)';
-			expect(parseColors(input)).to.equal(expected);
+			var input = {red:0,green:0,blue:255,alpha:0};
+			expect(parseColors(input).htmlColor).to.equal('rgba(0,0,255,0)');
 		  })
 		  
 		  it("should parse alpha", function() {
-			var input = {red:0,green:0,blue:0,alpha:255}
-			var expected = input;
-			expected.htmlColor = 'rgba(0,0,0,255)';
-			expect(parseColors(input)).to.equal(expected);
+			var input = {red:0,green:0,blue:0,alpha:1};
+			expect(parseColors(input).htmlColor).to.equal('rgba(0,0,0,1)');
 		  })
 		  
 		  it("should parse a combination", function() {
-			var input = {red:54,green:73,blue:20,alpha:123}
-			var expected = input;
-			expected.htmlColor = 'rgba(54,73,20,123)';
-			expect(parseColors(input)).to.equal(expected);
+			var input = {red:54,green:73,blue:20,alpha:.8};
+			expect(parseColors(input).htmlColor).to.equal('rgba(54,73,20,0.8)');
+		  })
+		  it("should parse float colors as percentages", function() {
+		  	var input = {red: "4.00000005960464E-1", "blue":"1E0", "green":"8.00000011920929E-1"};
+		  	expect(parseColors(input).htmlColor).to.equal('rgba(102,204,255,1)');
+		  })
+		  it("should parse integer 1 as iteself", function() {
+		  	var input = {red:1, green:"1", blue:1, alpha:.8};
+		  	expect(parseColors(input).htmlColor).to.equal('rgba(1,1,1,0.8)');
+		  })
+		  it("should parse float 1E0 as 255", function() {
+		  	var input = {red:"1E0", green:"1E0", blue: "1E0", alpha: 1};
+		  	expect(parseColors(input).htmlColor).to.equal('rgba(255,255,255,1)');
 		  })
 		  
 		  it("should parse null as black", function() {
 			  var input = null;
-			  var expected = {red: 0, green: 0, blue: 0, alpha: 1, htmlColor: 'rgba(0,0,0,255)'};
+			  var expected = {red: 0, green: 0, blue: 0, alpha: 1, htmlColor: 'rgba(0,0,0,1)'};
 			  expect(parseColors(input)).to.deep.equal(expected);
 		  })
 		  
 		  it("should parse undefined as black", function() {
 			  var input = undefined;
-			  var expected = {red: 0, green: 0, blue: 0, alpha: 1, htmlColor: 'rgba(0,0,0,255)'};
+			  var expected = {red: 0, green: 0, blue: 0, alpha: 1, htmlColor: 'rgba(0,0,0,1)'};
 			  expect(parseColors(input)).to.deep.equal(expected);
 		  })
   });


### PR DESCRIPTION
lib/propresenter_communication.js: 
handle pro6-style colors (0-1.0 floating point, scale to css 0-255)
Retain support for 0-255 color specs passing through as is.
Correct sense of tests for undefined or null color values

test/propresenter_communication_spec.js:
add test cases for pro6-style floating point color values
fix red/green/blue/alpha./combination tests, where assignment of a structure reference was causing tests to pass when they should not have.
adjust test cases for alpha value (css alpha is a 0-1 range, some tests were using 255)

> A (alpha) can be a <number> between 0 and 1, or a <percentage>, where the number 1 corresponds to 100% (full opacity)

